### PR TITLE
"Shutdown" translation not clear enought in French

### DIFF
--- a/common/po/fr.po
+++ b/common/po/fr.po
@@ -695,7 +695,7 @@ msgstr "Préférences"
 
 #: ../../qt/app.py:142
 msgid "Shutdown"
-msgstr "Arrêt"
+msgstr "Éteindre"
 
 #: ../../qt/app.py:143
 msgid "Shutdown system after snapshot has finished."


### PR DESCRIPTION
"Arrêt" means "Stop" and is not evident (stop what?). I clicked on it, thinking I would stop the backup, and I was very surprised to see the machine going down...

Shutdown is stronger, so here "Éteindre" is better for the French translation. This translation is already used just below: https://github.com/jej/backintime/blob/3132f4dd4fc627aef46e152696f5b98fb3db0298/common/po/fr.po#L701-L702

Hope it helps,
J.